### PR TITLE
Fix storybook relativePath depending on used platform

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -48,7 +48,16 @@ module.exports = {
                     );
 
                     // Updates the `resource.request` to reference our mocked module instead of the real one
-                    resource.request = relativePath;
+                    switch (process.platform) {
+                        case "win32": {
+                            resource.request = "./" + relativePath;
+                            break;
+                        }
+                        default: {
+                            resource.request = relativePath;
+                            break;
+                        }
+                    }
                 },
             ),
         ];


### PR DESCRIPTION
## Description

Fix `relativePath` variable in storybook depending on the platform.
For my case using windows, I now can run `yarn storybook` without any issue

Fixes #40 

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

I executed `yarn storybook` command from `package.json`

## Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
