### PR TITLE
Read Me updated to include Vite Js instead of Webpack  repo fork link

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,4 @@ In [Microsoft Edge](https://www.microsoft.com/en-us/edge), open up [edge://exten
 **Notable forks**
 
 -   [capaj](https://github.com/capaj/react-typescript-web-extension-starter) - Chakra-ui instead of TailwindCSS, Storybook removed
+-   [DesignString](https://github.com/DesignString/react-typescript-web-extension-starter) - Vite Js instead of Webpack


### PR DESCRIPTION
ReadMe file updated to include the link to forked repo using vitejs instead of webpack.