### PR TITLE
Fixed README.md | Manifest Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In [Brave](https://brave.com/), open up [brave://extensions](brave://extensions)
 <details>
   <summary>Loading the extension in Mozilla Firefox</summary>
 
-In [Mozilla Firefox](https://www.mozilla.org/en-US/firefox/new/), open up the [about:debugging](about:debugging) page in a new tab. Click the `This Firefox` link in the sidebar. One the `This Firefox` page, click the `Load Temporary Add-on...` button and select the `manfiest.json` from the `dist` directory in this repository - your extension should now be loaded.
+In [Mozilla Firefox](https://www.mozilla.org/en-US/firefox/new/), open up the [about:debugging](about:debugging) page in a new tab. Click the `This Firefox` link in the sidebar. One the `This Firefox` page, click the `Load Temporary Add-on...` button and select the `manifest.json` from the `dist` directory in this repository - your extension should now be loaded.
 
 ![Installed Extension in Mozilla Firefox](https://i.imgur.com/FKfTw4B.png "Installed Extension in Mozilla Firefox")
 


### PR DESCRIPTION
`manfiest.json` => `manifest.json`